### PR TITLE
Fixed parsing enums and method parameters with line breaks

### DIFF
--- a/src/GDShrapt.Reader.Tests/ParsingTests.cs
+++ b/src/GDShrapt.Reader.Tests/ParsingTests.cs
@@ -1127,14 +1127,52 @@ var node = get_node(node_path)
 
             AssertHelper.CompareCodeStrings(code, classDeclaration.ToString());
             AssertHelper.NoInvalidTokens(classDeclaration);
+		}
+
+		[TestMethod]
+		public void EnumTest2()
+		{
+			var reader = new GDScriptReader();
+
+			var code = @"enum {a,b,c = 10}";
+
+			var classDeclaration = reader.ParseFileContent(code);
+
+			Assert.IsNotNull(classDeclaration);
+			Assert.AreEqual(1, classDeclaration.Members.Count);
+			Assert.IsInstanceOfType(classDeclaration.Members[0], typeof(GDEnumDeclaration));
+
+			var enumDeclaration = (GDEnumDeclaration)classDeclaration.Members[0];
+
+			Assert.IsNull(enumDeclaration.Identifier);
+			Assert.AreEqual(3, enumDeclaration.Values.Count);
+
+			Assert.AreEqual("a", enumDeclaration.Values[0].Identifier?.ToString());
+			Assert.AreEqual("b", enumDeclaration.Values[1].Identifier?.ToString());
+			Assert.AreEqual("c", enumDeclaration.Values[2].Identifier?.ToString());
+
+			Assert.IsNull(enumDeclaration.Values[0].Value);
+			Assert.IsNull(enumDeclaration.Values[1].Value);
+			Assert.IsNotNull(enumDeclaration.Values[2].Value);
+
+			AssertHelper.CompareCodeStrings(code, classDeclaration.ToString());
+			AssertHelper.NoInvalidTokens(classDeclaration);
         }
 
         [TestMethod]
-        public void EnumTest2()
+        public void EnumLineBreakTest()
         {
             var reader = new GDScriptReader();
 
-            var code = @"enum {a,b,c = 10}";
+            var code = @"enum EnumName
+{
+a
+,
+b,
+c
+=
+10
+}";
 
             var classDeclaration = reader.ParseFileContent(code);
 
@@ -1144,7 +1182,7 @@ var node = get_node(node_path)
 
             var enumDeclaration = (GDEnumDeclaration)classDeclaration.Members[0];
 
-            Assert.IsNull(enumDeclaration.Identifier);
+            Assert.AreEqual("EnumName", enumDeclaration.Identifier.Sequence);
             Assert.AreEqual(3, enumDeclaration.Values.Count);
 
             Assert.AreEqual("a", enumDeclaration.Values[0].Identifier?.ToString());
@@ -1708,13 +1746,71 @@ var node = get_node(node_path)
             AssertHelper.NoInvalidTokens(expression);
         }
 
+		[TestMethod]
+		public void BaseMethodCallTest()
+		{
+			var reader = new GDScriptReader();
+
+			var code = @"func _init(res : string = ""Hello world"").(res) -> void:
+	._init(""1234"");
+    pass";
+
+			var @class = reader.ParseFileContent(code);
+
+			Assert.IsNotNull(@class);
+			Assert.AreEqual(1, @class.Methods.Count());
+
+			var method = @class.Methods.First();
+			Assert.IsNotNull(method);
+
+			Assert.IsTrue((method.ReturnType as GDSingleTypeNode).Type.IsVoid);
+			Assert.AreEqual("_init", method.Identifier.Sequence);
+			Assert.AreEqual(1, method.Parameters.Count);
+			Assert.AreEqual(1, method.BaseCallParameters.Count);
+
+			var parameter = method.Parameters[0];
+			Assert.IsNotNull(parameter);
+
+			Assert.AreEqual("res", parameter.Identifier.Sequence);
+			Assert.AreEqual("string", (parameter.Type as GDSingleTypeNode)?.Type?.Sequence);
+			Assert.AreEqual("\"Hello world\"", parameter.DefaultValue.ToString());
+
+			var baseCallParameter = method.BaseCallParameters[0];
+
+			Assert.AreEqual("res", baseCallParameter.ToString());
+
+			Assert.AreEqual(2, method.Statements.Count);
+
+			var callStatement = method.Statements[0].CastOrAssert<GDExpressionStatement>();
+
+			Assert.IsInstanceOfType(callStatement.Tokens.Last(), typeof(GDSemiColon));
+
+			var callExpression = callStatement.Expression.CastOrAssert<GDCallExpression>();
+
+			Assert.AreEqual("._init", callExpression.CallerExpression.ToString());
+			Assert.AreEqual("\"1234\"", callExpression.Parameters.ToString());
+
+			var passStatement = method.Statements[1].CastOrAssert<GDExpressionStatement>().Expression.CastOrAssert<GDPassExpression>();
+
+			Assert.IsNotNull(passStatement);
+			Assert.AreEqual(1, passStatement.Tokens.Count());
+
+			AssertHelper.CompareCodeStrings(code, @class.ToString());
+			AssertHelper.NoInvalidTokens(@class);
+        }
+
         [TestMethod]
-        public void BaseMethodCallTest()
+        public void MethodDeclarationLineBreakTest()
         {
             var reader = new GDScriptReader();
 
-            var code = @"func _init(res : string = ""Hello world"").(res) -> void:
-	._init(""1234"");
+            var code = @"func function_name(
+res
+:
+string
+=
+""Hello world""
+) -> int:
     pass";
 
             var @class = reader.ParseFileContent(code);
@@ -1725,10 +1821,10 @@ var node = get_node(node_path)
             var method = @class.Methods.First();
             Assert.IsNotNull(method);
 
-            Assert.IsTrue((method.ReturnType as GDSingleTypeNode).Type.IsVoid);
-            Assert.AreEqual("_init", method.Identifier.Sequence);
+            Assert.IsTrue((method.ReturnType as GDSingleTypeNode).Type.IsInt);
+            Assert.AreEqual("function_name", method.Identifier.Sequence);
             Assert.AreEqual(1, method.Parameters.Count);
-            Assert.AreEqual(1, method.BaseCallParameters.Count);
+            Assert.AreEqual(0, method.BaseCallParameters.Count);
 
             var parameter = method.Parameters[0];
             Assert.IsNotNull(parameter);
@@ -1737,22 +1833,9 @@ var node = get_node(node_path)
             Assert.AreEqual("string", (parameter.Type as GDSingleTypeNode)?.Type?.Sequence);
             Assert.AreEqual("\"Hello world\"", parameter.DefaultValue.ToString());
 
-            var baseCallParameter = method.BaseCallParameters[0];
+            Assert.AreEqual(1, method.Statements.Count);
 
-            Assert.AreEqual("res", baseCallParameter.ToString());
-
-            Assert.AreEqual(2, method.Statements.Count);
-
-            var callStatement = method.Statements[0].CastOrAssert<GDExpressionStatement>();
-
-            Assert.IsInstanceOfType(callStatement.Tokens.Last(), typeof(GDSemiColon));
-
-            var callExpression = callStatement.Expression.CastOrAssert<GDCallExpression>();
-
-            Assert.AreEqual("._init", callExpression.CallerExpression.ToString());
-            Assert.AreEqual("\"1234\"", callExpression.Parameters.ToString());
-
-            var passStatement = method.Statements[1].CastOrAssert<GDExpressionStatement>().Expression.CastOrAssert<GDPassExpression>();
+            var passStatement = method.Statements[0].CastOrAssert<GDExpressionStatement>().Expression.CastOrAssert<GDPassExpression>();
 
             Assert.IsNotNull(passStatement);
             Assert.AreEqual(1, passStatement.Tokens.Count());

--- a/src/GDShrapt.Reader/Declarations/GDEnumDeclaration.cs
+++ b/src/GDShrapt.Reader/Declarations/GDEnumDeclaration.cs
@@ -113,8 +113,7 @@
         {
             if (_form.IsOrLowerState(State.Values))
             {
-                _form.State = State.FigureCloseBracket;
-                state.PushAndPassNewLine(Values);
+                _form.AddBeforeActiveToken(new GDNewLine());
                 return;
             }
 

--- a/src/GDShrapt.Reader/Declarations/GDEnumValueDeclaration.cs
+++ b/src/GDShrapt.Reader/Declarations/GDEnumValueDeclaration.cs
@@ -4,7 +4,9 @@
         ITokenOrSkipReceiver<GDIdentifier>,
         ITokenOrSkipReceiver<GDColon>,
         ITokenOrSkipReceiver<GDAssign>,
-        ITokenOrSkipReceiver<GDExpression>
+        ITokenOrSkipReceiver<GDExpression>,
+        ITokenReceiver<GDNewLine>,
+        INewLineReceiver
     {
         bool _checkedColon;
 
@@ -75,7 +77,7 @@
                         this.ResolveAssign(c, state);
                     break;
                 case State.Value:
-                    this.ResolveExpression(c, state, _intendation);
+                    this.ResolveExpression(c, state, _intendation, this);
                     break;
                 default:
                     state.PopAndPass(c);
@@ -193,6 +195,28 @@
             if (_form.IsOrLowerState(State.Value))
             {
                 _form.State = State.Completed;
+                return;
+            }
+
+            throw new GDInvalidStateException();
+        }
+
+        void ITokenReceiver<GDNewLine>.HandleReceivedToken(GDNewLine token)
+        {
+            if (_form.State != State.Completed)
+            {
+                _form.AddBeforeActiveToken(token);
+                return;
+            }
+
+            throw new GDInvalidStateException();
+        }
+
+        void INewLineReceiver.HandleReceivedToken(GDNewLine token)
+        {
+            if (_form.State != State.Completed)
+            {
+                _form.AddBeforeActiveToken(token);
                 return;
             }
 

--- a/src/GDShrapt.Reader/Declarations/GDParameterDeclaration.cs
+++ b/src/GDShrapt.Reader/Declarations/GDParameterDeclaration.cs
@@ -5,7 +5,9 @@
         ITokenOrSkipReceiver<GDColon>,
         ITokenOrSkipReceiver<GDTypeNode>,
         ITokenOrSkipReceiver<GDAssign>,
-        ITokenOrSkipReceiver<GDExpression>
+        ITokenOrSkipReceiver<GDExpression>,
+        ITokenReceiver<GDNewLine>,
+        INewLineReceiver
     {
         public GDIdentifier Identifier
         {
@@ -79,7 +81,7 @@
                     this.ResolveAssign(c, state);
                     break;
                 case State.DefaultValue:
-                    this.ResolveExpression(c, state, _intendation);
+                    this.ResolveExpression(c, state, _intendation, this);
                     break;
                 default:
                     state.PopAndPass(c);
@@ -216,6 +218,28 @@
             if (_form.IsOrLowerState(State.DefaultValue))
             {
                 _form.State = State.Completed;
+                return;
+            }
+
+            throw new GDInvalidStateException();
+        }
+
+        void ITokenReceiver<GDNewLine>.HandleReceivedToken(GDNewLine token)
+        {
+            if (_form.State != State.Completed)
+            {
+                _form.AddBeforeActiveToken(token);
+                return;
+            }
+
+            throw new GDInvalidStateException();
+        }
+
+        void INewLineReceiver.HandleReceivedToken(GDNewLine token)
+        {
+            if (_form.State != State.Completed)
+            {
+                _form.AddBeforeActiveToken(token);
                 return;
             }
 

--- a/src/GDShrapt.Reader/Declarations/GDParameterDeclaration.cs
+++ b/src/GDShrapt.Reader/Declarations/GDParameterDeclaration.cs
@@ -89,7 +89,7 @@
 
         internal override void HandleNewLineChar(GDReadingState state)
         {
-            state.PopAndPassNewLine();
+            _form.AddBeforeActiveToken(new GDNewLine());
         }
 
         public override GDNode CreateEmptyInstance()

--- a/src/GDShrapt.Reader/Expressions/GDArrayInitializerExpression.cs
+++ b/src/GDShrapt.Reader/Expressions/GDArrayInitializerExpression.cs
@@ -90,6 +90,11 @@
 
             state.PopAndPassNewLine();
         }
+        internal override void HandleSharpChar(GDReadingState state)
+        {
+            _form.AddBeforeActiveToken(state.Push(new GDComment()));
+            state.PassSharpChar();
+        }
 
         public override GDNode CreateEmptyInstance()
         {

--- a/src/GDShrapt.Reader/Expressions/GDAwaitExpression.cs
+++ b/src/GDShrapt.Reader/Expressions/GDAwaitExpression.cs
@@ -94,6 +94,17 @@
             state.PopAndPassNewLine();
         }
 
+        internal override void HandleSharpChar(GDReadingState state)
+        {
+            if (_form.State == State.CloseBracket || _form.State == State.Parameters)
+            {
+                _form.AddBeforeActiveToken(state.Push(new GDComment()));
+                state.PassSharpChar();
+            }
+            else
+                base.HandleSharpChar(state);
+        }
+
         public override GDNode CreateEmptyInstance()
         {
             return new GDAwaitExpression();

--- a/src/GDShrapt.Reader/Expressions/GDBracketExpression.cs
+++ b/src/GDShrapt.Reader/Expressions/GDBracketExpression.cs
@@ -88,6 +88,13 @@
             }
         }
 
+        internal override void HandleSharpChar(GDReadingState state)
+        {
+            _form.AddBeforeActiveToken(state.Push(new GDComment()));
+            state.PassSharpChar();
+        }
+
+
         public override GDNode CreateEmptyInstance()
         {
             return new GDBracketExpression();

--- a/src/GDShrapt.Reader/Expressions/GDCallExpression.cs
+++ b/src/GDShrapt.Reader/Expressions/GDCallExpression.cs
@@ -98,6 +98,12 @@
             state.PopAndPassNewLine();
         }
 
+        internal override void HandleSharpChar(GDReadingState state)
+        {
+            _form.AddBeforeActiveToken(state.Push(new GDComment()));
+            state.PassSharpChar();
+        }
+
         public override GDNode CreateEmptyInstance()
         {
             return new GDCallExpression();

--- a/src/GDShrapt.Reader/Expressions/GDDictionaryInitializerExpression.cs
+++ b/src/GDShrapt.Reader/Expressions/GDDictionaryInitializerExpression.cs
@@ -81,6 +81,17 @@
             state.PopAndPassNewLine();
         }
 
+        internal override void HandleSharpChar(GDReadingState state)
+        {
+            if (_form.State != State.Completed)
+            {
+                _form.AddBeforeActiveToken(state.Push(new GDComment()));
+                state.PassSharpChar();
+            }
+            else
+                base.HandleSharpChar(state);
+        }
+
         public override GDNode CreateEmptyInstance()
         {
             return new GDDictionaryInitializerExpression();

--- a/src/GDShrapt.Reader/Expressions/GDMethodExpression.cs
+++ b/src/GDShrapt.Reader/Expressions/GDMethodExpression.cs
@@ -188,6 +188,17 @@ namespace GDShrapt.Reader
             state.PopAndPassNewLine();
         }
 
+        internal override void HandleSharpChar(GDReadingState state)
+        {
+            if (_form.State == State.CloseBracket || _form.State == State.Parameters)
+            {
+                _form.AddBeforeActiveToken(state.Push(new GDComment()));
+                state.PassSharpChar();
+            }
+            else
+                base.HandleSharpChar(state);
+        }
+
         internal override void Visit(IGDVisitor visitor)
         {
             visitor.Visit(this);

--- a/src/GDShrapt.Reader/Expressions/GDYieldExpression.cs
+++ b/src/GDShrapt.Reader/Expressions/GDYieldExpression.cs
@@ -94,6 +94,17 @@
             state.PopAndPassNewLine();
         }
 
+        internal override void HandleSharpChar(GDReadingState state)
+        {
+            if (_form.State == State.CloseBracket || _form.State == State.Parameters)
+            {
+                _form.AddBeforeActiveToken(state.Push(new GDComment()));
+                state.PassSharpChar();
+            }
+            else
+                base.HandleSharpChar(state);
+        }
+
         public override GDNode CreateEmptyInstance()
         {
             return new GDYieldExpression();

--- a/src/GDShrapt.Reader/Resolvers/GDExpressionResolver.cs
+++ b/src/GDShrapt.Reader/Resolvers/GDExpressionResolver.cs
@@ -484,8 +484,20 @@
 
                     Owner.HandleReceivedToken(last.RebuildRootOfPriorityIfNeeded());
 
-                    // Send all tokens after Single operator to current reader
+                    // Send all tokens after Single operator to the current reader
                     foreach (var token in operatorExpression.Form.GetAllTokensAfter(1))
+                        state.PassString(token.ToString());
+                }
+                else if (last is GDDualOperatorExpression dualOperatorExpression &&
+                    dualOperatorExpression.RightExpression == null &&
+                    dualOperatorExpression.Operator == null)
+                {
+                    last = dualOperatorExpression.LeftExpression;
+
+                    Owner.HandleReceivedToken(last.RebuildRootOfPriorityIfNeeded());
+
+                    // Send all tokens after Left expression to the current reader
+                    foreach (var token in dualOperatorExpression.Form.GetAllTokensAfter(0))
                         state.PassString(token.ToString());
                 }
                 else


### PR DESCRIPTION
While using this library (which is totally awesome btw) on a personal project, I noticed that it does not handle line breaks on enums and method declarations. I attempted to fix this myself and added some tests to support such cases, which were also properly parsed by Godot itself

Cases that it was failing to parse were like this

```
enum State
{
	STATE_IDLE
	,
	STATE_JUMP
	=
	5
	,
	STATE_SHOOT
}
```

```
func _test_func(
	m
	:
	float
		= 
	10.5
	,
	m2
	= null, m3 = 1 << 3
) -> int:
	return a*m + State.STATE_JUMP;
```

which are extreme examples, but even simpler cases like simply opening brakets after a line break on a enum declaration were failing already

There is another similar case that is failing, but that I did not manage to fix by myself, so I'll be opening an issue for it :)

Hope it all looks good!