### PR TITLE
Adding .editorconfig file to avoid indentation issues on diffs

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = space
+indent_size = 4

--- a/src/GDShrapt.Reader/Building/GD_LIST.cs
+++ b/src/GDShrapt.Reader/Building/GD_LIST.cs
@@ -131,7 +131,7 @@ namespace GDShrapt.Reader
 
                 bool previousMemberIsAttribute = false;
                 bool currentMemberIsAttribute = false;
-                bool isCustomAttribute = false;
+                //bool isCustomAttribute = false;
                 bool isNotAttributeMet = false;
 
 


### PR DESCRIPTION
Also commenting a single unused variable that was throwing a warning on build