### PR TITLE
Added support for Typed Dictionaries, added in Godot 4.4

### DIFF
--- a/src/GDShrapt.Reader.Tests/ParsingTests.cs
+++ b/src/GDShrapt.Reader.Tests/ParsingTests.cs
@@ -789,6 +789,7 @@ else:
             AssertHelper.NoInvalidTokens(statement);
         }
 
+
         [TestMethod]
         public void StringTest()
         {
@@ -3031,6 +3032,32 @@ var dict3: Dictionary[ int , bool ] = {
             AssertHelper.NoInvalidTokens(@class);
         }
 
+
+        [TestMethod]
+        public void ParseTypedDictionaryTest2()
+        {
+            var reader = new GDScriptReader();
+
+            var code = @"
+@export var typed_key_value: Dictionary[int, String ] = { 1: ""first value"", 2: ""second value"", 3: ""etc"" }
+@export var typed_key: Dictionary[ int, Variant] = { 0: ""any value"", 10: 3.14, 100: null }
+@export var typed_value: Dictionary [ Variant , int ] = { ""any value"": 0, 123: 456, null: -1 }";
+
+            var @class = reader.ParseFileContent(code);
+
+            Assert.IsNotNull(@class);
+
+            var types = @class.AllNodes.OfType<GDDictionaryTypeNode>();
+            
+            types.Select(x => x.ToString()).Should().BeEquivalentTo(new[] {
+                "Dictionary[int, String ]",
+                "Dictionary[ int, Variant]",
+                "Dictionary [ Variant , int ]"
+            });
+
+            AssertHelper.CompareCodeStrings(code, @class.ToString());
+            AssertHelper.NoInvalidTokens(@class);
+        }
 
         [TestMethod]
         public void ParseAttributesTest()

--- a/src/GDShrapt.Reader/Resolvers/GDTypeResolver.cs
+++ b/src/GDShrapt.Reader/Resolvers/GDTypeResolver.cs
@@ -69,6 +69,32 @@ namespace GDShrapt.Reader
                         _type = null;
                         return;
                     }
+                    else if (_type.IsDictionary)
+                    {
+                        var dictionaryTypeNode = new GDDictionaryTypeNode();
+
+                        state.Pop();
+
+                        Owner.HandleReceivedToken(dictionaryTypeNode);
+
+                        state.Push(dictionaryTypeNode);
+
+                        var sequence = _type.Sequence;
+                        for (int i = 0; i < sequence.Length; i++)
+                            state.PassChar(sequence[i]);
+
+                        if (_space != null)
+                        {
+                            for (int i = 0; i < _space.Sequence.Length; i++)
+                                state.PassChar(_space.Sequence[i]);
+
+                            _space = null;
+                        }
+
+                        state.PassChar(c);
+                        _type = null;
+                        return;
+                    }
                     else
                     {
                         Owner.HandleReceivedToken(new GDSingleTypeNode() { Type = _type });

--- a/src/GDShrapt.Reader/SimpleTokens/Keywords/GDArrayKeyword.cs
+++ b/src/GDShrapt.Reader/SimpleTokens/Keywords/GDArrayKeyword.cs
@@ -6,7 +6,7 @@
 
         public override GDSyntaxToken Clone()
         {
-            return new GDAwaitKeyword();
+            return new GDArrayKeyword();
         }
     }
 }

--- a/src/GDShrapt.Reader/SimpleTokens/Keywords/GDDictionaryKeyword.cs
+++ b/src/GDShrapt.Reader/SimpleTokens/Keywords/GDDictionaryKeyword.cs
@@ -1,0 +1,12 @@
+﻿namespace GDShrapt.Reader
+{
+    public sealed class GDDictionaryKeyword : GDKeyword
+    {
+        public override string Sequence => "Dictionary";
+
+        public override GDSyntaxToken Clone()
+        {
+            return new GDDictionaryKeyword();
+        }
+    }
+}

--- a/src/GDShrapt.Reader/Types/GDSingleTypeNode.cs
+++ b/src/GDShrapt.Reader/Types/GDSingleTypeNode.cs
@@ -3,9 +3,9 @@
     public class GDSingleTypeNode : GDTypeNode,
         ITokenOrSkipReceiver<GDType>
     {
-        public override GDTypeNode SubType => null;
         public override bool IsArray => Type?.IsArray ?? false;
-       
+        public override bool IsDictionary => Type?.IsDictionary ?? false;
+
         public GDType Type
         {
             get => _form.Token0;

--- a/src/GDShrapt.Reader/Types/GDStringTypeNode.cs
+++ b/src/GDShrapt.Reader/Types/GDStringTypeNode.cs
@@ -3,8 +3,8 @@
     public class GDStringTypeNode : GDTypeNode,
         ITokenOrSkipReceiver<GDStringNode>
     {
-        public override GDTypeNode SubType => null;
         public override bool IsArray => false;
+        public override bool IsDictionary => false;
 
         public GDStringNode Path
         {

--- a/src/GDShrapt.Reader/Types/GDSubTypeNode.cs
+++ b/src/GDShrapt.Reader/Types/GDSubTypeNode.cs
@@ -6,7 +6,7 @@
         ITokenOrSkipReceiver<GDType>
     {
         public override bool IsArray => false;
-        public override GDTypeNode SubType => null;
+        public override bool IsDictionary => false;
         public GDTypeNode OverType
         {
             get => _form.Token0;

--- a/src/GDShrapt.Reader/Types/GDTypeNode.cs
+++ b/src/GDShrapt.Reader/Types/GDTypeNode.cs
@@ -2,8 +2,8 @@
 {
     public abstract class GDTypeNode : GDNode
     {
-        public abstract GDTypeNode SubType { get; }
         public abstract bool IsArray { get; }
+        public abstract bool IsDictionary { get; }
         public abstract string BuildName();
     }
 }

--- a/src/GDShrapt.Reader/Walking/GDVisitor.cs
+++ b/src/GDShrapt.Reader/Walking/GDVisitor.cs
@@ -389,15 +389,25 @@
 
         public virtual void Left(GDSingleTypeNode t)
         {
-            // Nothing
-        }
+			// Nothing
+		}
 
-        public virtual void Visit(GDArrayTypeNode t)
+		public virtual void Visit(GDArrayTypeNode t)
+		{
+			// Nothing
+		}
+
+        public virtual void Visit(GDDictionaryTypeNode t)
         {
             // Nothing
         }
 
         public virtual void Left(GDArrayTypeNode t)
+        {
+            // Nothing
+        }
+
+        public virtual void Left(GDDictionaryTypeNode t)
         {
             // Nothing
         }

--- a/src/GDShrapt.Reader/Walking/IGDVisitor.cs
+++ b/src/GDShrapt.Reader/Walking/IGDVisitor.cs
@@ -45,6 +45,7 @@
         void Visit(GDSetAccessorMethodDeclaration d);
         void Visit(GDSingleTypeNode type);
         void Visit(GDArrayTypeNode type);
+        void Visit(GDDictionaryTypeNode type);
         void Visit(GDGetAccessorMethodDeclaration d);
 
         void Left(GDWhileStatement s);
@@ -85,6 +86,7 @@
         void Left(GDSetAccessorMethodDeclaration d);
         void Left(GDSingleTypeNode type);
         void Left(GDArrayTypeNode type);
+        void Left(GDDictionaryTypeNode type);
         void Left(GDGetAccessorMethodDeclaration d);
 
         void EnterListChild(GDNode node);


### PR DESCRIPTION
Other than the creation of the Dictionary Keyword and TypeNode, I also removed the SubType property of the GDTypeNode as only Arrays were using it and Dictionaries have two sub types