### PR TITLE
Fixed CreateEmptyInstance in some classes

### DIFF
--- a/src/GDShrapt.Reader/Declarations/Property/GDGetAccessorBodyDeclaration.cs
+++ b/src/GDShrapt.Reader/Declarations/Property/GDGetAccessorBodyDeclaration.cs
@@ -55,7 +55,7 @@
 
         public override GDNode CreateEmptyInstance()
         {
-            return new GDGetAccessorMethodDeclaration();
+            return new GDGetAccessorBodyDeclaration();
         }
 
         internal override void Visit(IGDVisitor visitor)

--- a/src/GDShrapt.Reader/Declarations/Property/GDSetAccessorBodyDeclaration.cs
+++ b/src/GDShrapt.Reader/Declarations/Property/GDSetAccessorBodyDeclaration.cs
@@ -80,7 +80,7 @@
 
         public override GDNode CreateEmptyInstance()
         {
-            return new GDGetAccessorMethodDeclaration();
+            return new GDSetAccessorBodyDeclaration();
         }
 
         internal override void Visit(IGDVisitor visitor)

--- a/src/GDShrapt.Reader/Declarations/Property/GDSetAccessorMethodDeclaration.cs
+++ b/src/GDShrapt.Reader/Declarations/Property/GDSetAccessorMethodDeclaration.cs
@@ -48,7 +48,7 @@
 
         public override GDNode CreateEmptyInstance()
         {
-            return new GDGetAccessorMethodDeclaration();
+            return new GDSetAccessorMethodDeclaration();
         }
 
         internal override void Visit(IGDVisitor visitor)

--- a/src/GDShrapt.Reader/Expressions/GDGetUniqueNodeExpression.cs
+++ b/src/GDShrapt.Reader/Expressions/GDGetUniqueNodeExpression.cs
@@ -60,7 +60,7 @@
 
         public override GDNode CreateEmptyInstance()
         {
-            return new GDGetNodeExpression();
+            return new GDGetUniqueNodeExpression();
         }
 
         internal override void Visit(IGDVisitor visitor)

--- a/src/GDShrapt.Reader/Types/GDStringTypeNode.cs
+++ b/src/GDShrapt.Reader/Types/GDStringTypeNode.cs
@@ -29,7 +29,7 @@
 
         public override GDNode CreateEmptyInstance()
         {
-            return new GDSingleTypeNode();
+            return new GDStringTypeNode();
         }
 
         internal override void HandleChar(char c, GDReadingState state)

--- a/src/GDShrapt.Reader/Types/GDSubTypeNode.cs
+++ b/src/GDShrapt.Reader/Types/GDSubTypeNode.cs
@@ -44,7 +44,7 @@
 
         public override GDNode CreateEmptyInstance()
         {
-            return new GDArrayTypeNode();
+            return new GDSubTypeNode();
         }
 
         internal override void Visit(IGDVisitor visitor)


### PR DESCRIPTION
Fixing what seemed to be some copypasta errors when overriding the CreateEmptyInstance method, which was causing issues with the Clone method.