### PR TITLE
Fix statement resolver splitting identifiers at underscore/digit boundaries

### DIFF
--- a/src/GDShrapt.Reader.Tests/Parsing/MethodParsingTests.cs
+++ b/src/GDShrapt.Reader.Tests/Parsing/MethodParsingTests.cs
@@ -290,5 +290,31 @@ static func f():
                 }
             }
         }
+
+        [TestMethod]
+        public void ParseMethod_IdentifierStartingWithKeyword_NotParsedAsStatement()
+        {
+            var reader = new GDScriptReader();
+
+            // Identifiers like match_id, var_name, for_each, if_enabled should not be
+            // split into keyword + remainder (e.g., "match" + "_id")
+            var code = "func test():\n\tmatch_id = 1\n\tvar_name = 2\n\tfor_each = 3\n\tif_enabled = 4\n\twhile_running = 5";
+
+            var declaration = reader.ParseFileContent(code);
+            Assert.IsNotNull(declaration);
+
+            var method = declaration.Methods.First();
+            Assert.AreEqual(5, method.Statements.Count);
+
+            // All should be expression statements (assignments), not keyword statements
+            foreach (var stmt in method.Statements)
+            {
+                Assert.IsInstanceOfType(stmt, typeof(GDExpressionStatement),
+                    $"Expected expression statement, got {stmt.GetType().Name}: {stmt.ToString()?.Trim()}");
+            }
+
+            AssertHelper.CompareCodeStrings(code, declaration.ToString());
+            AssertHelper.NoInvalidTokens(declaration);
+        }
     }
 }

--- a/src/GDShrapt.Reader/Resolvers/GDResolvingHelper.cs
+++ b/src/GDShrapt.Reader/Resolvers/GDResolvingHelper.cs
@@ -522,6 +522,7 @@ namespace GDShrapt.Reader
         public static bool IsCommentStartChar(this char c) => c == '#';
         public static bool IsSpace(this char c) => c == ' ' || c == '\t';
         public static bool IsIdentifierStartChar(this char c) => c == '_' || char.IsLetter(c);
+        public static bool IsIdentifierChar(this char c) => c == '_' || char.IsLetterOrDigit(c);
         public static bool IsExternalNameChar(this char c) => c == '_' || char.IsLetter(c) || char.IsDigit(c);
         public static bool IsStringStartChar(this char c) => c == '\'' || c == '\"';
         public static bool IsExpressionStopChar(this char c) => c == ',' || c == '}' || c == ')' || c == ']' || c == ':' || c == ';';

--- a/src/GDShrapt.Reader/Resolvers/GDStatementsResolver.cs
+++ b/src/GDShrapt.Reader/Resolvers/GDStatementsResolver.cs
@@ -129,7 +129,7 @@ namespace GDShrapt.Reader
             }
             else
             {
-                if (char.IsLetter(c))
+                if (c.IsIdentifierChar())
                 {
                     _sequenceBuilder.Append(c);
                 }


### PR DESCRIPTION
Fixes #23

The sequence builder in GDStatementsResolver only accumulated char.IsLetter chars, so identifiers like match_id were split into keyword "match" + "_id", producing a GDMatchStatement instead of an assignment.

- Add IsIdentifierChar extension method to GDResolvingHelper
- Use it in the statement resolver's continuation branch
- Add test covering match_id, var_name, for_each, if_enabled, while_running