### PR TITLE
Cache StartLine and NewLinesCount for O(1) access

### DIFF
--- a/src/GDShrapt.Reader/Basics/GDNode.cs
+++ b/src/GDShrapt.Reader/Basics/GDNode.cs
@@ -241,7 +241,17 @@ namespace GDShrapt.Reader
         /// </summary>
         public override int OriginLength => Tokens.Sum(x => x.OriginLength);
 
-        public override int NewLinesCount => Tokens.Sum(x => x.NewLinesCount);
+        private int _cachedNewLinesCount = -1;
+        public override int NewLinesCount
+        {
+            get
+            {
+                if (_cachedNewLinesCount >= 0)
+                    return _cachedNewLinesCount;
+                _cachedNewLinesCount = Tokens.Sum(x => x.NewLinesCount);
+                return _cachedNewLinesCount;
+            }
+        }
 
         public override int EndColumn
         {

--- a/src/GDShrapt.Reader/Basics/GDSyntaxToken.cs
+++ b/src/GDShrapt.Reader/Basics/GDSyntaxToken.cs
@@ -106,20 +106,28 @@ namespace GDShrapt.Reader
         public abstract GDSyntaxToken Clone();
 
         /// <summary>
-        /// Starting token's line in the code which is represented by the tree. Calculating property.
+        /// Starting token's line in the code which is represented by the tree.
+        /// Cached after first access for performance (AST is immutable after parsing).
         /// </summary>
+        private int _cachedStartLine = -1;
         public int StartLine
         {
             get
             {
+                if (_cachedStartLine >= 0)
+                    return _cachedStartLine;
+
                 var parent = _parent;
 
                 if (parent == null)
+                {
+                    _cachedStartLine = 0;
                     return 0;
+                }
 
                 var tokensBefore = parent.Form.GetTokensBefore(this);
-
-                return parent.StartLine + tokensBefore.Sum(x => x.NewLinesCount);
+                _cachedStartLine = parent.StartLine + tokensBefore.Sum(x => x.NewLinesCount);
+                return _cachedStartLine;
             }
         }
 


### PR DESCRIPTION
StartLine was computed on every access by recursively walking parent tokens to count newlines — O(depth × siblings) per call. Similarly, NewLinesCount on GDNode iterated all child tokens via LINQ Sum each time.

Both are now cached on first access. The AST is immutable after parsing so the cached values never go stale.

Resulted in a 9.4x improvement in perf in real-world usage that transpiles GDScript code.